### PR TITLE
Migration/add image url to decks

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,26 @@
+# Data migrations
+
+Before doing anything here with Firebase, it's probably a good idea to load up
+the Firebase project in question and smack the _Export Data_ button in the top
+right.
+
+## Deck Image URL
+
+Adds an `imageUrl` property to each deck in Firebase. Chooses the card with the
+longest name as the representative image.
+
+### To Run
+
+#### Development
+
+```sh
+$ cd bfm/migrations
+$ node deck-image-url.js
+```
+
+#### Production
+
+```sh
+$ cd bfm/migrations
+$ env NODE_ENV='production' node deck-image-url.js
+```

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -4,6 +4,13 @@ Before doing anything here with Firebase, it's probably a good idea to load up
 the Firebase project in question and smack the _Export Data_ button in the top
 right.
 
+## Setup
+
+```sh
+$ cd bfm/migrations
+$ npm install
+```
+
 ## Deck Image URL
 
 Adds an `imageUrl` property to each deck in Firebase. Chooses the card with the

--- a/migrations/config/development.js
+++ b/migrations/config/development.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  firebase: {
+    url: 'https://dim-glow-0245.firebaseio.com/'
+  },
+  webatrice: {
+    imageUrl: 'http://localhost:3000/images/'
+  }
+};

--- a/migrations/config/production.js
+++ b/migrations/config/production.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  firebase: {
+    url: 'https://dazzling-fire-7827.firebaseio.com/'
+  },
+  webatrice: {
+    imageUrl: 'https://big-furry-monster.herokuapp.com/images/'
+  }
+};

--- a/migrations/deck-image-url.js
+++ b/migrations/deck-image-url.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Migration script to update all decks with an image url.
+ */
+
+var _ = require('lodash');
+var request = require('request');
+
+var config = require('config');
+var FIREBASE_URL = config.get('firebase.url');
+var IMAGE_URL = config.get('webatrice.imageUrl');
+
+var DECKS_URL = FIREBASE_URL + 'decks.json';
+
+console.log('Downloading decks.');
+request.get(DECKS_URL, function (err, res, body) {
+  if (err) {
+    console.log(err);
+    process.exit(1);
+  }
+  // `body` is a JSON string that looks like:
+  // {
+  //   "-JmiiO_NkKCu84FGTjzj": {
+  //     "cardGroups": {},
+  //     "name": "...",
+  //     "owner": "-JmrdwBImvu1AgMsrDuu"
+  //   }, ...
+  // }
+
+  console.log('Parsing decks.');
+  var decks = JSON.parse(body);
+  _.forEach(decks, function (deck, id) {
+    var cardName = longestCardNameOfGroups(deck.cardGroups);
+    var cardImageUrl = encodeURI(IMAGE_URL + cardName);
+    deck.imageUrl = cardImageUrl;
+  });
+
+  console.log('Updating decks.');
+  request({
+    method: 'PUT',
+    url: DECKS_URL,
+    json: true,
+    body: decks
+  }, function (err) {
+    if (err) {
+      console.log(err);
+      process.exit(1);
+    }
+
+    console.log('Finished.');
+  });
+});
+
+/**
+ * Find the longest card name of all cards in the given card groups.
+ *
+ * @param {Object} cardGroup  Key/values are 'id': {'card': 'Mountain', ...}
+ *
+ * @return {String} Card name.
+ */
+function longestCardNameOfGroups(cardGroup) {
+  return _(cardGroup)
+    // Extract the card object value. {card: 'Fog', count: 2, board: 'main'}
+    .values()
+    // Map to the card name value.
+    .pluck('card')
+    // Sort shortest to longest.
+    .sortBy(function (name) {
+      return name.length;
+    })
+    // Get the longest one.
+    .last();
+}

--- a/migrations/package.json
+++ b/migrations/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bfm-migrations",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "config": "^1.17.1",
+    "lodash": "^3.10.1",
+    "request": "^2.67.0"
+  }
+}


### PR DESCRIPTION
A little script to update all the decks with `imageUrl` properties. This is in anticipation of a client side PR for making use of this property.

I already ran it against the dev instance, but not production.
